### PR TITLE
fix needed for vue-router to work on new sessions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -37,6 +37,7 @@ runs:
               npm ci
               npm run build
               cd dist
+              ln -s index.html 404.html
               if [ "none" !=  ${{ inputs.cname }} ]; then echo '${{ inputs.cname }}' > CNAME; fi
               git config --global user.email "${{ inputs.gitemail }}"
               git config --global user.name "${{ inputs.gitname }}"


### PR DESCRIPTION
- **ISSUE** any URLs that are _not  pointing at files_  are redirected to `404.html`
  - `<user>.gethub.io/<project>/any-build-file` works
  - `<user>.gethub.io/<project>/index.html` starts the app, then vue-router can take over
  - starting new sessions at `<user>.gethub.io/<project>/<router-paths>` = `404 error`
- **FIX** 
  - [as-seen-on stackoverflow](https://stackoverflow.com/questions/48521177/404-when-reloading-a-vue-website-published-to-github-pages/65539760) 
  - but lets use a simLink `build/index.html` ~> `build/404.html` (not a copy)
- **RESULT** 
  - now projects load from the root: `<user>.gethub.io/<project>/ `
  - and router-paths  are handled properly for new-session